### PR TITLE
attempt to fix device detection (port scanning)

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -7244,8 +7244,17 @@ MM::DeviceDetectionStatus CMMCore::detectDevice(char* label)
          std::string previousValue;
          for( std::vector< std::string>::iterator sit = propertiesToRestore.begin(); sit!= propertiesToRestore.end(); ++sit)
          {
-            previousValue = getProperty(port.c_str(), (*sit).c_str());
-            valuesToRestore[*sit] = std::string(previousValue);
+	    try
+            {
+               previousValue = getProperty(port.c_str(), (*sit).c_str());
+               valuesToRestore[*sit] = std::string(previousValue);
+	    }
+            catch(...)
+            {
+               LOG_ERROR(coreLogger_) <<
+                  "Device detection: error gathering property " << (*sit).c_str() <<
+                  " of port " << port << " while testing for device " << label;
+	    }
          }
       }
 


### PR DESCRIPTION
See https://github.com/micro-manager/micro-manager/issues/625.  This is attempt to gracefully exit when port properties can't be read.  Currently failure happens when the port is a TCP/IP port because this port doesn't have such properties and the whole detection process is aborted (even if the device has been found).